### PR TITLE
fix: Ensure `node-html-parser` doesn't strip comments

### DIFF
--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -234,7 +234,7 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
             const tpl = /** @type {string} */ (
                 /** @type {OutputAsset} */ (bundle['index.html']).source
             );
-            let htmlDoc = htmlParse(tpl);
+            let htmlDoc = htmlParse(tpl, { comment: true });
 
             // Create a tmp dir to allow importing & consuming the built modules,
             // before Rollup writes them to the disk
@@ -377,7 +377,7 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
                 }
 
                 // Reset HTML doc & head data
-                htmlDoc = htmlParse(tpl);
+                htmlDoc = htmlParse(tpl, { comment: true });
                 head = { lang: '', title: '', elements: new Set() };
 
                 // Add any discovered links to the list of routes to pre-render:

--- a/tests/fixtures/comments/index.html
+++ b/tests/fixtures/comments/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <!-- With Input HTML Comment -->
+        <script prerender type="module" src="/src/index.js"></script>
+    </body>
+</html>

--- a/tests/fixtures/comments/src/index.js
+++ b/tests/fixtures/comments/src/index.js
@@ -1,0 +1,3 @@
+export async function prerender() {
+    return '<h1>Simple Test Result <!-- With Output HTML Comment --></h1>';
+}

--- a/tests/fixtures/comments/vite.config.js
+++ b/tests/fixtures/comments/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { vitePrerenderPlugin } from 'vite-prerender-plugin';
+
+export default defineConfig({
+    plugins: [vitePrerenderPlugin()],
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -64,4 +64,13 @@ test('Should bail on merging preload & entry chunks if user configures `manualCh
     assert.equal((await fs.readdir(outDirAssets)).length, 2);
 });
 
+test('Should support comment nodes in returned HTML', async () => {
+    await loadFixture('comments', env);
+    await viteBuild(env.tmp.path);
+
+    const prerenderedHtml = await getOutputFile(env.tmp.path, 'index.html');
+    assert.match(prerenderedHtml, '<h1>Simple Test Result <!-- With Output HTML Comment --></h1>');
+    assert.match(prerenderedHtml, '<!-- With Input HTML Comment -->');
+});
+
 test.run();


### PR DESCRIPTION
Closes #1 

Fixes noticed hydration issue in the Vue example & unnoticed issue in the React example.