### PR TITLE
feat: Log prerendered routes upon build completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "format": "prettier --write --ignore-path .gitignore ."
   },
   "dependencies": {
+    "kolorist": "^1.8.0",
     "magic-string": "^0.30.6",
     "node-html-parser": "^6.1.12",
     "simple-code-frame": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      kolorist:
+        specifier: ^1.8.0
+        version: 1.8.0
       magic-string:
         specifier: ^0.30.6
         version: 0.30.10

--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -14,9 +14,6 @@ import * as kl from 'kolorist';
  * @typedef {import('vite').Rollup.OutputAsset} OutputAsset
  */
 
-const logger = createLogger();
-const loggerInfo = logger.info;
-
 /**
  * @param {import('./types.d.ts').PrerenderedRoute[]} routes
  */
@@ -132,17 +129,26 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
         config(config) {
             userEnabledSourceMaps = !!config.build?.sourcemap;
 
-            config.customLogger = {
-                ...config.customLogger,
-                info: (msg) => {
-                    loggerInfo(msg);
-                    if (msg.includes('built in')) {
-                        loggerInfo(
-                            kl.bold(`Prerendered ${routes.length} ${routes.length > 1 ? 'pages' : 'page'}:`) +
-                            prerenderedRoutes(routes)
-                        );
-                    }
-                },
+            if (!config.customLogger) {
+                const logger = createLogger(config.logLevel || 'info');
+                const loggerInfo = logger.info;
+
+                config.customLogger = {
+                    ...logger,
+                    info: (msg, options) => {
+                        loggerInfo(msg, options);
+                        if (msg.includes('built in')) {
+                            loggerInfo(
+                                kl.bold(
+                                    `Prerendered ${routes.length} ${
+                                        routes.length > 1 ? 'pages' : 'page'
+                                    }:`,
+                                ) + prerenderedRoutes(routes),
+                                options,
+                            );
+                        }
+                    },
+                };
             }
 
             // Enable sourcemaps for generating more actionable error messages

--- a/tests/fixtures/logs/prerendered-routes/index.html
+++ b/tests/fixtures/logs/prerendered-routes/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <script prerender type="module" src="/src/index.js"></script>
+    </body>
+</html>

--- a/tests/fixtures/logs/prerendered-routes/src/index.js
+++ b/tests/fixtures/logs/prerendered-routes/src/index.js
@@ -1,0 +1,13 @@
+export async function prerender({ url }) {
+    let links;
+    if (url == '/') {
+        links = new Set(['/foo']);
+    } else if (url == '/foo') {
+        links = new Set(['/bar']);
+    }
+
+    return {
+        html: `<h1>Simple Test Result</h1>`,
+        links,
+    };
+}

--- a/tests/fixtures/logs/prerendered-routes/vite.config.js
+++ b/tests/fixtures/logs/prerendered-routes/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { vitePrerenderPlugin } from 'vite-prerender-plugin';
+
+export default defineConfig({
+    plugins: [vitePrerenderPlugin()],
+});

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -34,6 +34,7 @@ export async function copyDependencies(cwd) {
     await copyNodeModule('simple-code-frame');
     await copyNodeModule('source-map');
     await copyNodeModule('stack-trace');
+    await copyNodeModule('kolorist');
 }
 
 /**
@@ -71,3 +72,5 @@ export async function outputFileExists(dir, file) {
 export async function writeFixtureFile(dir, filePath, content) {
     await fs.writeFile(path.join(dir, filePath), content);
 }
+
+export const stripColors = (str) => str.replace(/\x1b\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]/g, '');

--- a/tests/logs.test.js
+++ b/tests/logs.test.js
@@ -1,0 +1,30 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+import { setupTest, teardownTest, loadFixture, viteBuildCli } from './lib/lifecycle.js';
+
+let env;
+test.before.each(async () => {
+    env = await setupTest();
+});
+
+test.after.each(async () => {
+    await teardownTest(env);
+});
+
+test('Should support the `prerenderScript` plugin option', async () => {
+    await loadFixture('logs/prerendered-routes', env);
+    const output = await viteBuildCli(env.tmp.path);
+    await output.done;
+
+    const idx = output.stdout.findIndex((line) => line.includes('Prerendered'));
+    // The prerender info is pushed as a single log line
+    const stdout = output.stdout.slice(idx)[0];
+
+    assert.match(stdout, 'Prerendered 3 pages:\n');
+    assert.match(stdout, '/\n');
+    assert.match(stdout, '/foo [from /]\n');
+    assert.match(stdout, '/bar [from /foo]\n');
+});
+
+test.run();


### PR DESCRIPTION
Pretty much matches the old output from WMR, displaying which routes have been found & prerendered. Was missing it & I think it's useful for catching some mistakes here and there.

Ex:

![temp](https://github.com/user-attachments/assets/52cebf8c-be98-4ffd-9f81-ddac4fc48d1c)
