### PR TITLE
refactor: Strip map comments if user has not enabled sourcemaps

### DIFF
--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -136,7 +136,12 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
                 config.customLogger = {
                     ...logger,
                     info: (msg, options) => {
+                        if (msg.includes(' │ map:') && !userEnabledSourceMaps) {
+                            msg = msg.replace(/ │ map:.*/, '');
+                        }
+
                         loggerInfo(msg, options);
+
                         if (msg.includes('built in')) {
                             loggerInfo(
                                 kl.bold(

--- a/tests/logs.test.js
+++ b/tests/logs.test.js
@@ -2,6 +2,9 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 
 import { setupTest, teardownTest, loadFixture, viteBuildCli } from './lib/lifecycle.js';
+import { writeFixtureFile } from './lib/utils.js';
+
+const writeConfig = async (dir, content) => writeFixtureFile(dir, 'vite.config.js', content);
 
 let env;
 test.before.each(async () => {
@@ -12,19 +15,45 @@ test.after.each(async () => {
     await teardownTest(env);
 });
 
-test('Should support the `prerenderScript` plugin option', async () => {
+test('Should log which routes were prerendered & where they were discovered', async () => {
     await loadFixture('logs/prerendered-routes', env);
     const output = await viteBuildCli(env.tmp.path);
     await output.done;
 
-    const idx = output.stdout.findIndex((line) => line.includes('Prerendered'));
     // The prerender info is pushed as a single log line
-    const stdout = output.stdout.slice(idx)[0];
+    const stdout = output.stdout.find((line) => line.includes('Prerendered'));
 
     assert.match(stdout, 'Prerendered 3 pages:\n');
     assert.match(stdout, '/\n');
     assert.match(stdout, '/foo [from /]\n');
     assert.match(stdout, '/bar [from /foo]\n');
+});
+
+test('Should strip sourcemap sizes from logs if user has not enabled sourcemaps', async () => {
+    await loadFixture('logs/prerendered-routes', env);
+    const output = await viteBuildCli(env.tmp.path);
+    await output.done;
+
+    const stdout = output.stdout.find((line) => /dist\/assets\/index.*\.js/.test(line));
+    assert.not.match(stdout, '│ map:');
+});
+
+test('Should preserve sourcemap sizes from logs if user has enabled sourcemaps', async () => {
+    await loadFixture('logs/prerendered-routes', env);
+    await writeConfig(env.tmp.path, `
+        import { defineConfig } from 'vite';
+        import { vitePrerenderPlugin } from 'vite-prerender-plugin';
+
+        export default defineConfig({
+            build: { sourcemap: true },
+            plugins: [vitePrerenderPlugin()],
+        });
+    `);
+    const output = await viteBuildCli(env.tmp.path);
+    await output.done;
+
+    const stdout = output.stdout.find((line) => /dist\/assets\/index.*\.js/.test(line));
+    assert.match(stdout, '│ map:');
 });
 
 test.run();


### PR DESCRIPTION
Fixes a tiny implementation flaw.

We enable sourcemaps for all builds so that we can provide actionable feedback to users if prerendering fails, but if the user hasn't enabled sourcemaps themselves, we clean these up post-build so that they aren't sitting around. A tiny problem with this is that Vite logs out the source map size along side the asset size, resulting in something like this:

```
dist/assets/index-L8ExaPTv.js  0.95 kB │ gzip: 0.55 kB │ map: 0.61 kB
```

This could surprise users as the referenced map is nowhere to be found after the build and they didn't enable sourcemaps themselves.

As such, we'll simply use our custom logger to intercept & strip these map size comments when users haven't enabled sourcemaps themselves, giving us this:

```
dist/assets/index-L8ExaPTv.js  0.95 kB │ gzip: 0.55 kB
```