### PR TITLE
fix: Support custom output names

### DIFF
--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -303,8 +303,10 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
             for (const output of Object.keys(bundle)) {
                 if (!output.endsWith('.js') || bundle[output].type !== 'chunk') continue;
 
+                const assetPath = path.join(tmpDir, output);
+                await fs.mkdir(path.dirname(assetPath), { recursive: true });
                 await fs.writeFile(
-                    path.join(tmpDir, path.basename(output)),
+                    assetPath,
                     /** @type {OutputChunk} */ (bundle[output]).code,
                 );
 
@@ -372,7 +374,7 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
             let prerender;
             try {
                 const m = await import(
-                    `file://${path.join(tmpDir, path.basename(prerenderEntry.fileName))}`
+                    `file://${path.join(tmpDir, prerenderEntry.fileName)}`
                 );
                 prerender = m.prerender;
             } catch (e) {

--- a/tests/fixtures/named-chunks/index.html
+++ b/tests/fixtures/named-chunks/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <script prerender type="module" src="/src/index.js"></script>
+    </body>
+</html>

--- a/tests/fixtures/named-chunks/src/index.js
+++ b/tests/fixtures/named-chunks/src/index.js
@@ -1,0 +1,5 @@
+import('./split-chunk.js');
+
+export async function prerender() {
+    return `<h1>Simple Test Result</h1>`;
+}

--- a/tests/fixtures/named-chunks/src/split-chunk.js
+++ b/tests/fixtures/named-chunks/src/split-chunk.js
@@ -1,0 +1,3 @@
+globalThis.splitChunk = function splitChunk() {
+    console.log('splitChunk');
+}

--- a/tests/fixtures/named-chunks/vite.config.js
+++ b/tests/fixtures/named-chunks/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { vitePrerenderPlugin } from 'vite-prerender-plugin';
+
+export default defineConfig({
+    plugins: [vitePrerenderPlugin()],
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -73,4 +73,33 @@ test('Should support comment nodes in returned HTML', async () => {
     assert.match(prerenderedHtml, '<!-- With Input HTML Comment -->');
 });
 
+test('Should support custom output filenames', async () => {
+    await loadFixture('named-chunks', env);
+    await writeConfig(env.tmp.path, `
+        import { defineConfig } from 'vite';
+        import { vitePrerenderPlugin } from 'vite-prerender-plugin';
+
+        export default defineConfig({
+            build: {
+                rollupOptions: {
+                    output: {
+                        chunkFileNames: 'chunks/[name].[hash].js',
+                    }
+                }
+            },
+            plugins: [vitePrerenderPlugin()],
+        });
+    `);
+    await viteBuild(env.tmp.path);
+
+    let message = '';
+    try {
+        await viteBuild(env.tmp.path);
+    } catch (error) {
+        message = error.message;
+    }
+
+    assert.match(message, '');
+});
+
 test.run();


### PR DESCRIPTION
Not 100% sure on the reason behind the `path.basename` calls -- might've been some testing code of mine that ended up shipping.