### PR TITLE
feat: head.base support

### DIFF
--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -480,6 +480,16 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
                         htmlDoc.querySelector('html').setAttribute('lang', enc(head.lang));
                     }
 
+                    if (head.base) {
+                        const htmlBase = htmlHead.querySelector('base');
+                        htmlBase
+                            ? htmlBase.setAttribute('href', enc(head.base))
+                            : htmlHead.insertAdjacentHTML(
+                                  'afterbegin',
+                                  `<base href="${enc(head.base)}" >`,
+                              );
+                    }
+
                     if (head.elements) {
                         // Inject HTML links at the end of <head> for any stylesheets injected during rendering of the page:
                         htmlHead.insertAdjacentHTML(

--- a/src/plugins/types.d.ts
+++ b/src/plugins/types.d.ts
@@ -8,6 +8,7 @@ export interface Head {
     lang: string;
     title: string;
     elements: Set<HeadElement>;
+    base: string;
 }
 
 export interface PrerenderedRoute {

--- a/tests/prerender-api.test.js
+++ b/tests/prerender-api.test.js
@@ -94,6 +94,25 @@ test('Should support `head.title` property', async () => {
     assert.match(prerenderedHtml, '<title>My Prerendered Site</title>');
 });
 
+test('Should support `head.base` property', async () => {
+    await loadFixture('simple', env);
+    await writeEntry(
+        env.tmp.path,
+        `
+        export async function prerender() {
+            return {
+                html: '<h1>Hello, World!</h1>',
+                head: { base: '/' },
+            };
+        }
+    `,
+    );
+    await viteBuild(env.tmp.path);
+
+    const prerenderedHtml = await getOutputFile(env.tmp.path, 'index.html');
+    assert.match(prerenderedHtml, '<base href="/" >');
+});
+
 test('Should support `head.elements` property', async () => {
     await loadFixture('simple', env);
     await writeEntry(env.tmp.path, `


### PR DESCRIPTION
### Problem

If user has custom `viteConfig.base` (e.g. `./`) and uses `additionalPrerenderRoutes`, then additional pages have head tags like `<script src="./static/main.js" >` and browser can't resolve this src on non `/` pages (e.g. on `/a/b/c/index.html`)

It may be fixed by `<base>` tag, but it should be defined before any another `<head>` tags, so we are not ables to prived it with `head.elements`

### Solution

Support `head.base` option
