### PR TITLE
feat: Support `replace` in prerender head.elements to remove existing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ export async function prerender(data) {
             // Sets any additional elements you want injected into the `<head>`:
             //   <link rel="stylesheet" href="foo.css">
             //   <meta property="og:title" content="Social media title">
+            //   <meta name="description" content="My cool description">
             elements: new Set([
                 { type: 'link', props: { rel: 'stylesheet', href: 'foo.css' } },
                 { type: 'meta', props: { property: 'og:title', content: 'Social media title' } },
+                // Use `replace` with a CSS selector to remove existing elements before inserting:
+                { type: 'meta', props: { name: 'description', content: 'My cool description' }, replace: 'meta[name="description"]' },
             ]),
         },
     };

--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -481,6 +481,15 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
                     }
 
                     if (head.elements) {
+                        // Remove existing elements that should be replaced
+                        for (const element of head.elements) {
+                            if (element.replace) {
+                                for (const existing of htmlHead.querySelectorAll(element.replace)) {
+                                    existing.remove();
+                                }
+                            }
+                        }
+
                         // Inject HTML links at the end of <head> for any stylesheets injected during rendering of the page:
                         htmlHead.insertAdjacentHTML(
                             'beforeend',

--- a/src/plugins/types.d.ts
+++ b/src/plugins/types.d.ts
@@ -2,6 +2,8 @@ export interface HeadElement {
     type: string;
     props: Record<string, string>;
     children?: string;
+    /** CSS selector to find and remove existing elements before inserting this one */
+    replace?: string;
 }
 
 export interface Head {


### PR DESCRIPTION
## Feat: Support `replace` in prerender head.elements to remove existing tags

This PR adds an **optional** way to replace existing `<head>` tags when using the prerender API’s `head.elements`, without changing any default behavior.

### What changed

- **New optional `replace` field on `head.elements` items**
  - Each element inside `head.elements` may now include `replace?: string`
  - `replace` is a **CSS selector** used to target existing elements in the HTML template

- **Replacement logic (opt-in, default behavior unchanged)**
  - **Only** when `replace` is provided:
    - Before inserting the new element, the plugin runs `querySelectorAll(replace)` on `<head>` and removes **all** matching nodes
  - When `replace` is not provided, the plugin behaves exactly as before (elements are simply appended to `<head>`)

- **Documentation update**
  - The README’s “Advanced Prerender Options” example now includes a `replace` usage snippet (e.g. replacing an existing `meta[name="description"]`)

### Why

Some projects include default head tags in the HTML template (like `description`, `canonical`, `og:*`), but want prerendering to generate route-specific values. Without this, users can end up with duplicate `<meta>` tags. The new `replace` option lets users precisely control what gets replaced using a familiar CSS selector.

### Compatibility / impact

- **Non-breaking**: only adds an optional field
- **No default behavior changes**: opt-in only
- **Minimal scope**: affects only elements that explicitly set `replace`, and only touches matching nodes within `<head>`

### Example

```js
head: {
  elements: new Set([
    {
      type: 'meta',
      props: { name: 'description', content: 'My page description' },
      replace: 'meta[name="description"]',
    },
  ]),
}
```