### PR TITLE
chore: Support Vite 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format": "prettier --write --ignore-path .gitignore ."
   },
   "peerDependencies": {
-    "vite": "5.x || 6.x || 7.x"
+    "vite": "5.x || 6.x || 7.x || 8.x"
   },
   "dependencies": {
     "kolorist": "^1.8.0",

--- a/src/plugins/prerender-plugin.js
+++ b/src/plugins/prerender-plugin.js
@@ -371,6 +371,9 @@ export function prerenderPlugin({ prerenderScript, renderTarget, additionalPrere
                         );
                         const sourceContent = await fs.readFile(sourcePath, 'utf-8');
 
+                        // TODO: `line` uses below are off by one with Vite 8, might be a bug?
+                        // Not the end of the world for now though it's annoying.
+
                         // `simple-code-frame` has 1-based line numbers
                         const frame = createCodeFrame(sourceContent, line - 1, column);
                         message += `\n

--- a/tests/fixtures/environments/cloudflare/src/server.js
+++ b/tests/fixtures/environments/cloudflare/src/server.js
@@ -1,1 +1,2 @@
 console.log("Server is running...");
+export default {};

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -47,7 +47,7 @@ test('Should bail on merging preload & entry chunks if user configures `manualCh
             build: {
                 rollupOptions: {
                     output: {
-                        manualChunks: {}
+                        manualChunks() {}
                     }
                 }
             },


### PR DESCRIPTION
Closes #33 

Bumped the deps locally & ran the suite, all pass (after a couple tweaks) except the source map errors test. For whatever reason, with Vite 8, line numbers are off by 1. Not a blocking issue though.