### PR TITLE
Upgrade pnpm supply-chain safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.0.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+minimumReleaseAge: 10080
+
+blockExoticSubdeps: true
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
- upgrade pinned pnpm usage to pnpm 11
- configure a 7-day `minimumReleaseAge` window for installs
- explicitly block exotic transitive dependencies

## Why
Upgraded every repo to pnpm 11, so we inherit the ecosystem install-cooldown behaviour. It's not a fix on its own. It buys us a window.

## Testing
- Not run; config-only change.
